### PR TITLE
Hide Spectator Advancements in Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ To edit the default configuration of the game navigate to the [config.yml](https
 | `prevent-bed-explosions` | true | Prevent players from exploding beds | Beds can still be used in the Overworld |
 | `prevent-respawn-anchor-explosions` | true | Prevent players from exploding respawn anchors | Respawn anchors can still be used in the Nether |
 | `must-kill-dragon-to-win` | true | Players must kill the dragon to win | If set to false, the last remaining team will be declared the winner, otherwise if all teams are dead players will be respawned |
-| `give-armor` | false | Give leather armor to players at start and on respawn | Armor is dyed to the team color and has curse of vanishing |
 | `hide-spectator-advancements` | true | Hide advancements earned by spectators from being announced in chat. | Spectators are defined as anyone in spectator /gamemode |
+| `give-armor` | false | Give leather armor to players at start and on respawn | Armor is dyed to the team color and has curse of vanishing |
 | `teams` | See [teams](#teams) | The team names and colors | A team requires a name and a color, `name: "COLOR"`, the color must be a [Minecraft color code](https://minecraft.gamepedia.com/Formatting_codes#Color_codes): BLACK, DARK_BLUE, DARK_GREEN, DARK_AQUA, DARK_RED, DARK_PURPLE, GOLD, GRAY, DARK_GRAY, BLUE, GREEN, AQUA, RED, LIGHT_PURPLE, YELLOW, WHITE |
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ To edit the default configuration of the game navigate to the [config.yml](https
 | `prevent-respawn-anchor-explosions` | true | Prevent players from exploding respawn anchors | Respawn anchors can still be used in the Nether |
 | `must-kill-dragon-to-win` | true | Players must kill the dragon to win | If set to false, the last remaining team will be declared the winner, otherwise if all teams are dead players will be respawned |
 | `give-armor` | false | Give leather armor to players at start and on respawn | Armor is dyed to the team color and has curse of vanishing |
+| `hide-spectator-advancements-in-chat` | true | Hide advancements earned by spectators from being announced in chat. | Spectators are defined as anyone in spectator /gamemode |
 | `teams` | See [teams](#teams) | The team names and colors | A team requires a name and a color, `name: "COLOR"`, the color must be a [Minecraft color code](https://minecraft.gamepedia.com/Formatting_codes#Color_codes): BLACK, DARK_BLUE, DARK_GREEN, DARK_AQUA, DARK_RED, DARK_PURPLE, GOLD, GRAY, DARK_GRAY, BLUE, GREEN, AQUA, RED, LIGHT_PURPLE, YELLOW, WHITE |
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To edit the default configuration of the game navigate to the [config.yml](https
 | `prevent-respawn-anchor-explosions` | true | Prevent players from exploding respawn anchors | Respawn anchors can still be used in the Nether |
 | `must-kill-dragon-to-win` | true | Players must kill the dragon to win | If set to false, the last remaining team will be declared the winner, otherwise if all teams are dead players will be respawned |
 | `give-armor` | false | Give leather armor to players at start and on respawn | Armor is dyed to the team color and has curse of vanishing |
-| `hide-spectator-advancements-in-chat` | true | Hide advancements earned by spectators from being announced in chat. | Spectators are defined as anyone in spectator /gamemode |
+| `hide-spectator-advancements` | true | Hide advancements earned by spectators from being announced in chat. | Spectators are defined as anyone in spectator /gamemode |
 | `teams` | See [teams](#teams) | The team names and colors | A team requires a name and a color, `name: "COLOR"`, the color must be a [Minecraft color code](https://minecraft.gamepedia.com/Formatting_codes#Color_codes): BLACK, DARK_BLUE, DARK_GREEN, DARK_AQUA, DARK_RED, DARK_PURPLE, GOLD, GRAY, DARK_GRAY, BLUE, GREEN, AQUA, RED, LIGHT_PURPLE, YELLOW, WHITE |
 
 ## Issues

--- a/src/main/java/com/github/speedrunshowdown/SpeedrunShowdown.java
+++ b/src/main/java/com/github/speedrunshowdown/SpeedrunShowdown.java
@@ -9,14 +9,7 @@ import com.github.speedrunshowdown.commands.StartCommand;
 import com.github.speedrunshowdown.commands.StopCommand;
 import com.github.speedrunshowdown.commands.SuddenDeathCommand;
 import com.github.speedrunshowdown.commands.WinCommand;
-import com.github.speedrunshowdown.listeners.BedUseListener;
-import com.github.speedrunshowdown.listeners.BlockDamageListener;
-import com.github.speedrunshowdown.listeners.CompassUseListener;
-import com.github.speedrunshowdown.listeners.DragonKillListener;
-import com.github.speedrunshowdown.listeners.PlayerDeathListener;
-import com.github.speedrunshowdown.listeners.PlayerRespawnListener;
-import com.github.speedrunshowdown.listeners.PortalEnterListener;
-import com.github.speedrunshowdown.listeners.RespawnAnchorUseListener;
+import com.github.speedrunshowdown.listeners.*;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
@@ -67,6 +60,7 @@ public class SpeedrunShowdown extends JavaPlugin implements Runnable {
         getServer().getPluginManager().registerEvents(new RespawnAnchorUseListener(this), this);
         getServer().getPluginManager().registerEvents(new PortalEnterListener(this), this);
         getServer().getPluginManager().registerEvents(new DragonKillListener(this), this);
+        getServer().getPluginManager().registerEvents(new AdvancementListener(this), this);
 
         saveDefaultConfig();
 
@@ -114,7 +108,7 @@ public class SpeedrunShowdown extends JavaPlugin implements Runnable {
 
         speedrunShowdownScoreboard.update();
     }
-    
+
     public void start() {
         // If already running, cancel start
         if (running) {

--- a/src/main/java/com/github/speedrunshowdown/SpeedrunShowdown.java
+++ b/src/main/java/com/github/speedrunshowdown/SpeedrunShowdown.java
@@ -3,12 +3,7 @@ package com.github.speedrunshowdown;
 import java.util.Arrays;
 import java.util.Iterator;
 
-import com.github.speedrunshowdown.commands.GiveCompassCommand;
-import com.github.speedrunshowdown.commands.GiveArmorCommand;
-import com.github.speedrunshowdown.commands.StartCommand;
-import com.github.speedrunshowdown.commands.StopCommand;
-import com.github.speedrunshowdown.commands.SuddenDeathCommand;
-import com.github.speedrunshowdown.commands.WinCommand;
+import com.github.speedrunshowdown.commands.*;
 import com.github.speedrunshowdown.listeners.*;
 
 import org.bukkit.ChatColor;

--- a/src/main/java/com/github/speedrunshowdown/listeners/AdvancementListener.java
+++ b/src/main/java/com/github/speedrunshowdown/listeners/AdvancementListener.java
@@ -17,7 +17,7 @@ public class AdvancementListener implements Listener {
 
     @EventHandler
     public void onAdvancementObtained(final PlayerAdvancementDoneEvent event) {
-        // Unfortunately Spigot does not provide a message to cancel this event so we have to come up with our own tomfoolery.
+        // Unfortunately Spigot does not provide a method to cancel this event so we have to come up with our own tomfoolery.
         if (plugin.isRunning() && plugin.getConfig().getBoolean("hide-spectator-advancements-in-chat")) {
             event.getPlayer().getWorld().setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, true);
             if (event.getPlayer().getGameMode() == GameMode.SPECTATOR) {

--- a/src/main/java/com/github/speedrunshowdown/listeners/AdvancementListener.java
+++ b/src/main/java/com/github/speedrunshowdown/listeners/AdvancementListener.java
@@ -17,18 +17,19 @@ public class AdvancementListener implements Listener {
 
     @EventHandler
     public void onAdvancementObtained(final PlayerAdvancementDoneEvent event) {
-        // Unfortunately Spigot does not provide a method to cancel this event so we have to come up with our own tomfoolery.
+        // If plugin is running and should hide spectator advancements,
+        // turn announce advancements gamerule off and schedule it to return to its original value
         if (plugin.isRunning() && plugin.getConfig().getBoolean("hide-spectator-advancements")) {
-            event.getPlayer().getWorld().setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, true);
+            final boolean announceAdvancements = event.getPlayer().getWorld().getGameRuleValue(GameRule.ANNOUNCE_ADVANCEMENTS);
+            plugin.getLogger().info("Announce advancements: " + announceAdvancements);
             if (event.getPlayer().getGameMode() == GameMode.SPECTATOR) {
                 event.getPlayer().getWorld().setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, false);
                 Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
                     @Override
                     public void run() {
-                        event.getPlayer().getWorld().setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, true);
+                        event.getPlayer().getWorld().setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, announceAdvancements);
                     }
                 }, 1L);
-
             }
         }
     }

--- a/src/main/java/com/github/speedrunshowdown/listeners/AdvancementListener.java
+++ b/src/main/java/com/github/speedrunshowdown/listeners/AdvancementListener.java
@@ -18,7 +18,7 @@ public class AdvancementListener implements Listener {
     @EventHandler
     public void onAdvancementObtained(final PlayerAdvancementDoneEvent event) {
         // Unfortunately Spigot does not provide a method to cancel this event so we have to come up with our own tomfoolery.
-        if (plugin.isRunning() && plugin.getConfig().getBoolean("hide-spectator-advancements-in-chat")) {
+        if (plugin.isRunning() && plugin.getConfig().getBoolean("hide-spectator-advancements")) {
             event.getPlayer().getWorld().setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, true);
             if (event.getPlayer().getGameMode() == GameMode.SPECTATOR) {
                 event.getPlayer().getWorld().setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, false);

--- a/src/main/java/com/github/speedrunshowdown/listeners/AdvancementListener.java
+++ b/src/main/java/com/github/speedrunshowdown/listeners/AdvancementListener.java
@@ -1,0 +1,36 @@
+package com.github.speedrunshowdown.listeners;
+
+import com.github.speedrunshowdown.SpeedrunShowdown;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.GameRule;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerAdvancementDoneEvent;
+
+public class AdvancementListener implements Listener {
+    private SpeedrunShowdown plugin;
+
+    public AdvancementListener(SpeedrunShowdown plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onAdvancementObtained(final PlayerAdvancementDoneEvent event) {
+        // Unfortunately Spigot does not provide a message to cancel this event so we have to come up with our own tomfoolery.
+        if (plugin.isRunning() && plugin.getConfig().getBoolean("hide-spectator-advancements-in-chat")) {
+            event.getPlayer().getWorld().setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, true);
+            if (event.getPlayer().getGameMode() == GameMode.SPECTATOR) {
+                event.getPlayer().getWorld().setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, false);
+                Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
+                    @Override
+                    public void run() {
+                        event.getPlayer().getWorld().setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, true);
+                    }
+                }, 1L);
+
+            }
+        }
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,7 @@ prevent-bed-explosions: true
 prevent-respawn-anchor-explosions: true
 must-kill-dragon-to-win: true
 give-armor: false
+hide-spectator-advancements-in-chat: true
 teams:
   redstone: "RED"
   lapis: "BLUE"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,8 +7,8 @@ indestructable-spawners: true
 prevent-bed-explosions: true
 prevent-respawn-anchor-explosions: true
 must-kill-dragon-to-win: true
+hide-spectator-advancements: true
 give-armor: false
-hide-spectator-advancements-in-chat: true
 teams:
   redstone: "RED"
   lapis: "BLUE"


### PR DESCRIPTION
Hello!
While watching Speedrun Showdown I noticed a flaw in the strategy of the game. Specifically, I noticed that players would react and make decisions based off the advancements spectators earned. (I.E.: If a spectator earned the bastion advancement, you may assume that the other team could be close to a bastion and make a decision based off that whether or not it is true)

Personally, I feel like the spectators should be in no way involved with the gameplay therefore their advancement messages should be hidden.

This pull request adds a configuration option that will either enable or disable hiding spectator's advancement messages in the chat.

On first glance this PR might look scuffed as hell but unfortunately Spigot does not provide a Cancellable event for Advancement completion. Fortunately this code works perfectly to hide the messages.

1. It successfully blocks when you /give spectators items that trigger advancements.
2. The message won't appear if you enter a structure that gives an advancement.
3. It also won't send the message if you enter while in the view of the player and they enter an advancement structure (the player's advancement message shows, but not the spectator's).
4. Entering dimensions hides the spectator's advancement gain.

Tested everything above with multiple accounts on Spigot 1.16.1.

:)